### PR TITLE
Add -tx and -channel command line options

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Requirements:
 
 To fetch and build:
 
-    go get -u layeh.com/barnard
+    go install layeh.com/barnard@latest
 
 After running the command above, `barnard` will be compiled as `$(go env GOPATH)/bin/barnard`.
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ To fetch and build:
 
 After running the command above, `barnard` will be compiled as `$(go env GOPATH)/bin/barnard`.
 
+## Development Environment Setup
+apt install libalut-dev libopus-dev
+go mod init
+go get
+go build
+
 ## Manual
 
 ### Key bindings

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ go build
 
 ### Key bindings
 
-- <kbd>F1</kbd>: toggle voice transmission
+- <kbd>F1</kbd>: show help
+- <kbd>F2</kbd>: toggle voice transmission
 - <kbd>Ctrl+L</kbd>: clear chat log
 - <kbd>Tab</kbd>: toggle focus between chat and user tree
 - <kbd>Page Up</kbd>: scroll chat up

--- a/README.md
+++ b/README.md
@@ -16,15 +16,21 @@ Requirements:
 
 To fetch and build:
 
-    go install layeh.com/barnard@latest
+````
+apt install libalut-dev libopus-dev
+go install layeh.com/barnard@latest
+````
 
 After running the command above, `barnard` will be compiled as `$(go env GOPATH)/bin/barnard`.
 
 ## Development Environment Setup
+
+````
 apt install libalut-dev libopus-dev
 go mod init
 go get
 go build
+````
 
 ## Manual
 

--- a/barnard.go
+++ b/barnard.go
@@ -12,8 +12,10 @@ type Barnard struct {
 	Config *gumble.Config
 	Client *gumble.Client
 
-	Address   string
-	TLSConfig tls.Config
+	Address        string
+	TLSConfig      tls.Config
+	StartTX        bool
+	StartupChannel string
 
 	Stream *gumbleopenal.Stream
 

--- a/client.go
+++ b/client.go
@@ -17,6 +17,7 @@ func (b *Barnard) start() {
 	var err error
 	_, err = gumble.DialWithDialer(new(net.Dialer), b.Address, b.Config, &b.TLSConfig)
 	if err != nil {
+		b.Ui.Close()
 		fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)
 	}
@@ -26,6 +27,7 @@ func (b *Barnard) start() {
 		os.Setenv("ALSOFT_LOGLEVEL", "0")
 	}
 	if stream, err := gumbleopenal.New(b.Client); err != nil {
+		b.Ui.Close()
 		fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)
 	} else {

--- a/main.go
+++ b/main.go
@@ -18,13 +18,17 @@ func main() {
 	password := flag.String("password", "", "the password of the server")
 	insecure := flag.Bool("insecure", false, "skip server certificate verification")
 	certificate := flag.String("certificate", "", "PEM encoded certificate and private key")
+	channel := flag.String("channel", "", "the channel to join")
+	starttx := flag.Bool("tx", false, "start transmitting immediately")
 
 	flag.Parse()
 
 	// Initialize
 	b := Barnard{
-		Config:  gumble.NewConfig(),
-		Address: *server,
+		Config:         gumble.NewConfig(),
+		Address:        *server,
+		StartTX:        *starttx,
+		StartupChannel: *channel,
 	}
 
 	b.Config.Username = *username

--- a/ui.go
+++ b/ui.go
@@ -163,6 +163,15 @@ func (b *Barnard) OnUiInitialize(ui *uiterm.Ui) {
 
 	b.start()
 
+	b.AddOutputLine("F1       : Toggle Voice Transmission")
+	b.AddOutputLine("CTRL+L   : Clear chat log")
+	b.AddOutputLine("TAB      : Toggle focus between chat and user tree")
+	b.AddOutputLine("Page Up  : Scroll chat up")
+	b.AddOutputLine("Page Down: Scroll chat down")
+	b.AddOutputLine("HOME     : Scroll chat to the top")
+	b.AddOutputLine("END      : Scroll chat to the bottom")
+	b.AddOutputLine("F10      : Quit")
+
 	if b.StartTX {
 		b.ToggleVoice()
 	}

--- a/ui.go
+++ b/ui.go
@@ -153,7 +153,8 @@ func (b *Barnard) OnUiInitialize(ui *uiterm.Ui) {
 	ui.Add(uiViewTree, &b.UiTree)
 
 	b.Ui.AddKeyListener(b.OnFocusPress, uiterm.KeyTab)
-	b.Ui.AddKeyListener(b.OnVoiceToggle, uiterm.KeyF1)
+	b.Ui.AddKeyListener(b.ShowHelp, uiterm.KeyF1)
+	b.Ui.AddKeyListener(b.OnVoiceToggle, uiterm.KeyF2)
 	b.Ui.AddKeyListener(b.OnQuitPress, uiterm.KeyF10)
 	b.Ui.AddKeyListener(b.OnClearPress, uiterm.KeyCtrlL)
 	b.Ui.AddKeyListener(b.OnScrollOutputUp, uiterm.KeyPgup)
@@ -161,18 +162,7 @@ func (b *Barnard) OnUiInitialize(ui *uiterm.Ui) {
 	b.Ui.AddKeyListener(b.OnScrollOutputTop, uiterm.KeyHome)
 	b.Ui.AddKeyListener(b.OnScrollOutputBottom, uiterm.KeyEnd)
 
-	b.AddOutputLine("                Welcome to Barnard                ")
-	b.AddOutputLine("--------------------------------------------------")
-	b.AddOutputLine("HELP:")
-	b.AddOutputLine("F1       : Toggle Voice Transmission")
-	b.AddOutputLine("CTRL+L   : Clear chat log")
-	b.AddOutputLine("TAB      : Toggle focus between chat and user tree")
-	b.AddOutputLine("Page Up  : Scroll chat up")
-	b.AddOutputLine("Page Down: Scroll chat down")
-	b.AddOutputLine("HOME     : Scroll chat to the top")
-	b.AddOutputLine("END      : Scroll chat to the bottom")
-	b.AddOutputLine("F10      : Quit")
-	b.AddOutputLine("--------------------------------------------------")
+	b.showHelp()
 
 	b.start()
 
@@ -193,4 +183,24 @@ func (b *Barnard) OnUiResize(ui *uiterm.Ui, width, height int) {
 	ui.SetBounds(uiViewInputStatus, 0, height-2, width, height-1)
 	ui.SetBounds(uiViewOutput, 0, 1, width-20, height-2)
 	ui.SetBounds(uiViewTree, width-20, 1, width, height-2)
+}
+
+func (b *Barnard) showHelp() {
+	b.AddOutputLine("                Welcome to Barnard                ")
+	b.AddOutputLine("--------------------------------------------------")
+	b.AddOutputLine("HELP:")
+	b.AddOutputLine("F1       : Show this help message")
+	b.AddOutputLine("F2       : Toggle Voice Transmission")
+	b.AddOutputLine("CTRL+L   : Clear chat log")
+	b.AddOutputLine("TAB      : Toggle focus between chat and user tree")
+	b.AddOutputLine("Page Up  : Scroll chat up")
+	b.AddOutputLine("Page Down: Scroll chat down")
+	b.AddOutputLine("HOME     : Scroll chat to the top")
+	b.AddOutputLine("END      : Scroll chat to the bottom")
+	b.AddOutputLine("F10      : Quit")
+	b.AddOutputLine("--------------------------------------------------")
+}
+
+func (b *Barnard) ShowHelp(ui *uiterm.Ui, key uiterm.Key) {
+	b.showHelp()
 }

--- a/ui.go
+++ b/ui.go
@@ -161,8 +161,9 @@ func (b *Barnard) OnUiInitialize(ui *uiterm.Ui) {
 	b.Ui.AddKeyListener(b.OnScrollOutputTop, uiterm.KeyHome)
 	b.Ui.AddKeyListener(b.OnScrollOutputBottom, uiterm.KeyEnd)
 
-	b.start()
-
+	b.AddOutputLine("                Welcome to Barnard                ")
+	b.AddOutputLine("--------------------------------------------------")
+	b.AddOutputLine("HELP:")
 	b.AddOutputLine("F1       : Toggle Voice Transmission")
 	b.AddOutputLine("CTRL+L   : Clear chat log")
 	b.AddOutputLine("TAB      : Toggle focus between chat and user tree")
@@ -171,6 +172,9 @@ func (b *Barnard) OnUiInitialize(ui *uiterm.Ui) {
 	b.AddOutputLine("HOME     : Scroll chat to the top")
 	b.AddOutputLine("END      : Scroll chat to the bottom")
 	b.AddOutputLine("F10      : Quit")
+	b.AddOutputLine("--------------------------------------------------")
+
+	b.start()
 
 	if b.StartTX {
 		b.ToggleVoice()

--- a/ui.go
+++ b/ui.go
@@ -44,6 +44,11 @@ func (b *Barnard) AddOutputMessage(sender *gumble.User, message string) {
 }
 
 func (b *Barnard) OnVoiceToggle(ui *uiterm.Ui, key uiterm.Key) {
+	b.ToggleVoice()
+	ui.Refresh()
+}
+
+func (b *Barnard) ToggleVoice() {
 	if b.UiStatus.Text == "  Tx  " {
 		b.UiStatus.Text = " Idle "
 		b.UiStatus.Fg = uiterm.ColorBlack
@@ -55,7 +60,6 @@ func (b *Barnard) OnVoiceToggle(ui *uiterm.Ui, key uiterm.Key) {
 		b.UiStatus.Text = "  Tx  "
 		b.Stream.StartSource()
 	}
-	ui.Refresh()
 }
 
 func (b *Barnard) OnQuitPress(ui *uiterm.Ui, key uiterm.Key) {
@@ -158,6 +162,14 @@ func (b *Barnard) OnUiInitialize(ui *uiterm.Ui) {
 	b.Ui.AddKeyListener(b.OnScrollOutputBottom, uiterm.KeyEnd)
 
 	b.start()
+
+	if b.StartTX {
+		b.ToggleVoice()
+	}
+
+	if b.StartupChannel != "" {
+		b.Client.Self.Move(b.Client.Channels.Find(b.StartupChannel))
+	}
 }
 
 func (b *Barnard) OnUiResize(ui *uiterm.Ui, width, height int) {

--- a/uiterm/ui.go
+++ b/uiterm/ui.go
@@ -45,6 +45,7 @@ func New(manager UiManager) *Ui {
 
 func (ui *Ui) Close() {
 	if termbox.IsInit {
+		termbox.Close()
 		ui.close <- true
 	}
 }


### PR DESCRIPTION
The -tx flag causes the client to start transmitting immediately
The -channel flag causes the client to join the specified channel.
Change F1 to display some help text.
F2 is now the transmit toggle.

A group of ham radio operators are using barnard as part of a remote rig control mechanism. These command line flags make it possible to start barnard in a channel and immediately start transmitting. The hams are using these flags to broadcast their radio rx audio into mumble.